### PR TITLE
TAS-1354: connection/related-with-blocked API

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -5593,7 +5593,26 @@ paths:
     get:
       tags:
         - connect
-      summary: get related connect
+      summary: get related connect if status is not BLOCKED
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /connections/related-with-blocked/{identity_id}:
+    parameters:
+      - name: identity_id
+        required: true
+        in: path
+        description: identity id
+        schema:
+          type: string
+    get:
+      tags:
+        - connect
+      summary: get related connect even if status is BLOCKED
       security:
         - bearerAuth: []
       responses:

--- a/src/models/connect/read.js
+++ b/src/models/connect/read.js
@@ -111,3 +111,20 @@ export const related = async (identityId1, identityId2) => {
     throw new PermissionError()
   }
 }
+
+export const relatedWithBlocked = async (identityId1, identityId2) => {
+  try {
+    return app.db.get(
+      sql`SELECT c.*, row_to_json(i1.*) AS requested, row_to_json(i2.*) AS requester
+      FROM connections c
+      JOIN identities i1 ON i1.id=c.requested_id
+      JOIN identities i2 ON i2.id=c.requester_id    
+      WHERE 
+        (requester_id = ${identityId1} AND requested_id = ${identityId2}) OR
+        (requester_id = ${identityId2} AND requested_id = ${identityId1})
+    `
+    )
+  } catch {
+    throw new PermissionError()
+  }
+}

--- a/src/routes/connect.js
+++ b/src/routes/connect.js
@@ -22,6 +22,14 @@ router.get('/related/:identity_id', loginRequired, async (ctx) => {
   }
 })
 
+router.get('/related-with-blocked/:identity_id', loginRequired, async (ctx) => {
+  try {
+    ctx.body = { connect: await Connect.relatedWithBlocked(ctx.identity.id, ctx.params.identity_id) }
+  } catch {
+    ctx.body = { connect: null }
+  }
+})
+
 router.get('/:id', loginRequired, checkIdParams, connectPermission, async (ctx) => {
   ctx.body = await Connect.get(ctx.params.id)
 })


### PR DESCRIPTION
Implemented `connection/related-with-blocked/:identity_id` API to retrieve connection status even if status is `BLOCKED`