### PR TITLE
fix: replace external AI recommender with local SQL scoring

### DIFF
--- a/src/services/recommender/index.js
+++ b/src/services/recommender/index.js
@@ -1,23 +1,13 @@
-import axios from 'axios'
-import Config from '../../config.js'
 import Project from '../../models/project/index.js'
 import User from '../../models/user/index.js'
 import Applicant from '../../models/applicant/index.js'
-import Organization from '../../models/organization/index.js'
-import { getRecommendeds, recommended } from './model.js'
-
-const projectToQuery = (project) => {
-  return {
-    title: project.title,
-    description: project.description,
-    skills: project.skills
-  }
-}
+import { getRecommendeds, recommended, getRecommendedProjectIds, getSimilarProjectIds } from './model.js'
 
 export const recommendProjectByProject = async (id) => {
   const p = await Project.get(id)
-  const result = await axios.post(Config.ai.job_recommender_url, { query: projectToQuery(p) })
-  return Project.getAll(result.data.jobs)
+  const ids = await getSimilarProjectIds(p.skills, p.causes_tags, id, 10)
+  if (ids.length === 0) return []
+  return Project.getAll(ids)
 }
 
 export const recommendProjectByUser = async (username, options) => {
@@ -39,30 +29,24 @@ export const recommendProjectByUser = async (username, options) => {
       user.id
     )
 
-  const query = [
-    {
-      mission: user.mission,
-      bio: user.bio,
-      skills: user.skills,
-      social_causes: user.social_causes,
-      country: user.country
-    }
-  ]
-
   const applies = await Applicant.getByUserId(user.id, { limit: 10, offset: 0, filter: {}, sort: '-created_at' })
 
-  query.push(...(applies?.map((a) => projectToQuery(a.project)) || []))
   const [saves, notIntresteds] = await Promise.all([
     Project.getMarkedProjects(user.id, 'SAVE'),
     Project.getMarkedProjects(user.id, 'NOT_INTERESTED')
   ])
 
-  const result = await axios.post(Config.ai.jobs_recommender_url, {
-    query: query,
-    excludes: notIntresteds.map((m) => m.project_id),
-    intrests: saves.map((m) => m.project_id)
-  })
-  const projects = await Project.getAll(result.data.jobs, user.id)
+  const excludeIds = [
+    ...(applies?.map((a) => a.project_id) || []),
+    ...notIntresteds.map((m) => m.project_id)
+  ]
+
+  const savedIds = saves.map((m) => m.project_id)
+
+  const ids = await getRecommendedProjectIds(user, excludeIds, savedIds, 20)
+  if (ids.length === 0) return []
+
+  const projects = await Project.getAll(ids, user.id)
   let saved = []
   let i = 1
   for (const p of projects) {
@@ -73,102 +57,18 @@ export const recommendProjectByUser = async (username, options) => {
   return projects
 }
 
-export const recommendUserByUser = async (username) => {
-  const user = await User.getByUsername(username)
-  const query = [
-    {
-      mission: user.mission,
-      bio: user.bio,
-      skills: user.skills,
-      social_causes: user.social_causes,
-      country: user.country
-    }
-  ]
-
-  const applies = await Applicant.getByUserId(user.id, { limit: 5, offset: 0, filter: {}, sort: '-created_at' })
-
-  query.push(...(applies?.map((a) => projectToQuery(a.project)) || []))
-
-  const [saves, notIntresteds] = await Promise.all([
-    Project.getMarkedProjects(user.id, 'SAVE'),
-    Project.getMarkedProjects(user.id, 'NOT_INTERESTED')
-  ])
-
-  const result = await axios.post(Config.ai.talents_recommender_url, {
-    query: query,
-    excludes: notIntresteds.map((m) => m.project_id),
-    intrests: saves.map((m) => m.project_id)
-  })
-
-  return User.getAllProfile(result.data.talents, '-impact_points', user.id)
+export const recommendUserByUser = async () => {
+  return []
 }
 
-export const recommendUserByOrg = async (shortname) => {
-  const org = await Organization.getByShortname(shortname)
-  const query = [
-    {
-      mission: org.mission,
-      bio: org.bio,
-      skills: org.skills,
-      social_causes: org.social_causes,
-      country: org.country
-    }
-  ]
-
-  const projects = await Project.all(org.id, {
-    limit: 3,
-    offset: 0,
-    filter: { identity_id: org.id },
-    sort: '-created_at'
-  })
-
-  query.push(...(projects?.map((p) => projectToQuery(p)) || []))
-
-  const result = await axios.post(Config.ai.talents_recommender_url, { query: query })
-  return User.getAllProfile(result.data.talents, '-impact_points', org.id)
+export const recommendUserByOrg = async () => {
+  return []
 }
 
-export const recommendOrgByUser = async (username) => {
-  const user = await User.getByUsername(username)
-  const query = [
-    {
-      mission: user.mission,
-      bio: user.bio,
-      skills: user.skills,
-      social_causes: user.social_causes,
-      country: user.country
-    }
-  ]
-
-  const applies = await Applicant.getByUserId(user.id, { limit: 10, offset: 0, filter: {}, sort: '-created_at' })
-
-  query.push(...(applies?.map((a) => projectToQuery(a.project)) || []))
-
-  const result = await axios.post(Config.ai.orgs_recommender_url, { query: query })
-  return Organization.getAll(result.data.orgs)
+export const recommendOrgByUser = async () => {
+  return []
 }
 
-export const recommendOrgByOrg = async (shortname) => {
-  const org = await Organization.getByShortname(shortname)
-  const query = [
-    {
-      mission: org.mission,
-      bio: org.bio,
-      skills: org.skills,
-      social_causes: org.social_causes,
-      country: org.country
-    }
-  ]
-
-  const projects = await Project.all(org.id, {
-    limit: 3,
-    offset: 0,
-    filter: { identity_id: org.id },
-    sort: '-created_at'
-  })
-
-  query.push(...(projects?.map((p) => projectToQuery(p)) || []))
-
-  const result = await axios.post(Config.ai.orgs_recommender_url, { query: query })
-  return Organization.getAll(result.data.orgs)
+export const recommendOrgByOrg = async () => {
+  return []
 }

--- a/src/services/recommender/model.js
+++ b/src/services/recommender/model.js
@@ -19,8 +19,8 @@ export const recommended = async (identityId, entityId, entityType, order) => {
     true,
     ${order}
   )
-  ON CONFLICT (identity_id, entity_id) DO 
-  UPDATE SET 
+  ON CONFLICT (identity_id, entity_id) DO
+  UPDATE SET
     recommened_count=EXCLUDED.recommened_count+1,
     updated_at=NOW()
   RETURNING *
@@ -39,4 +39,69 @@ export const getRecommendeds = async (identityId, type, { offset = 0, limit = 10
       ORDER BY order_number ASC
       LIMIT ${limit} OFFSET ${offset}`)
   return rows
+}
+
+export const getRecommendedProjectIds = async (user, excludeIds, savedIds, limit = 20) => {
+  const socialCauses = user.social_causes || []
+  const skills = user.skills || []
+  const country = user.country || ''
+
+  // Get causes from saved projects to boost similar ones
+  let savedCauses = []
+  if (savedIds.length > 0) {
+    const { rows: savedRows } = await app.db.query(sql`
+      SELECT DISTINCT unnest(causes_tags) AS cause
+      FROM projects WHERE id = ANY(${savedIds})
+    `)
+    savedCauses = savedRows.map((r) => r.cause)
+  }
+
+  const allCauses = [...new Set([...socialCauses, ...savedCauses])]
+
+  const { rows } = await app.db.query(sql`
+    SELECT p.id,
+      COALESCE(
+        (SELECT COUNT(*) FROM unnest(p.causes_tags) c WHERE c = ANY(${allCauses.length > 0 ? allCauses : ['']})),
+      0) * 3
+      + COALESCE(
+        (SELECT COUNT(*) FROM unnest(p.skills) s WHERE s = ANY(${skills.length > 0 ? skills : ['']})),
+      0) * 2
+      + CASE WHEN p.country = ${country} THEN 1 ELSE 0 END
+      + CASE WHEN p.promoted THEN 1 ELSE 0 END
+      AS score
+    FROM projects p
+    WHERE p.status = 'ACTIVE'
+      AND p.kind = 'JOB'
+      AND (p.expires_at IS NULL OR p.expires_at > NOW())
+      AND (${excludeIds.length > 0} = false OR p.id != ALL(${excludeIds.length > 0 ? excludeIds : ['00000000-0000-0000-0000-000000000000']}))
+    ORDER BY score DESC, p.created_at DESC
+    LIMIT ${limit}
+  `)
+
+  return rows.map((r) => r.id)
+}
+
+export const getSimilarProjectIds = async (skills, causesTags, excludeId, limit = 10) => {
+  const safeSkills = skills && skills.length > 0 ? skills : ['']
+  const safeCauses = causesTags && causesTags.length > 0 ? causesTags : ['']
+
+  const { rows } = await app.db.query(sql`
+    SELECT p.id,
+      COALESCE(
+        (SELECT COUNT(*) FROM unnest(p.causes_tags) c WHERE c = ANY(${safeCauses})),
+      0) * 3
+      + COALESCE(
+        (SELECT COUNT(*) FROM unnest(p.skills) s WHERE s = ANY(${safeSkills})),
+      0) * 2
+      AS score
+    FROM projects p
+    WHERE p.status = 'ACTIVE'
+      AND p.kind = 'JOB'
+      AND (p.expires_at IS NULL OR p.expires_at > NOW())
+      AND p.id != ${excludeId}
+    ORDER BY score DESC, p.created_at DESC
+    LIMIT ${limit}
+  `)
+
+  return rows.map((r) => r.id)
 }


### PR DESCRIPTION
## Summary
- Replace broken external AI recommendation service (`Config.ai.jobs_recommender_url`) with local SQL-based scoring queries
- Score projects by overlap with user profile: social causes (+3), skills (+2), country (+1), promoted (+1)
- Add `getSimilarProjectIds` for project-to-project recommendations using the same scoring approach
- Keep existing 7-day cache logic and `recommends` table persistence unchanged
- Gracefully return empty arrays for user/org recommendation endpoints that depended on the removed AI service

## Test plan
- [ ] Call `GET /:username/recommend/jobs` — should return scored projects
- [ ] Call `GET /:id/similars` — should return related projects
- [ ] Verify cached results are returned within 7-day window
- [ ] Verify user/org recommendation endpoints return empty arrays without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)